### PR TITLE
Enable markdownKeymap for editor

### DIFF
--- a/src/ts/editor.ts
+++ b/src/ts/editor.ts
@@ -5,7 +5,7 @@ import {defaultKeymap, historyKeymap, indentWithTab, history} from "@codemirror/
 import {closeBrackets, closeBracketsKeymap} from "@codemirror/autocomplete"
 import {highlightSelectionMatches, search} from "search"
 import {autocompletion, completionKeymap} from "@codemirror/autocomplete"
-import {markdown, markdownLanguage } from "@codemirror/lang-markdown"
+import {markdown, markdownKeymap, markdownLanguage } from "@codemirror/lang-markdown"
 import {ankiImagePaste } from "./CodeMirror.extensions/ankiImagePaste"
 import {classHighlighter} from '@lezer/highlight'
 import {Subscript, Superscript, Strikethrough, Table} from "@lezer/markdown"
@@ -77,6 +77,7 @@ class Editor {
         keymap.of([
           ...km,
           ...closeBracketsKeymap,
+          ...markdownKeymap,
           ...defaultKeymap,
           indentWithTab,
           ...historyKeymap,


### PR DESCRIPTION
It is currently quite annoying that when writing a (bullet) list, you need to type `- ` for every item again. Luckily, CodeMirror can automatically continue lists, like many other editors do.

This PR enables the two keybinds provided by https://github.com/codemirror/lang-markdown#user-content-markdownkeymap.

It binds Enter to [insertNewlineContinueMarkup](https://github.com/codemirror/lang-markdown#user-content-insertnewlinecontinuemarkup) and Backspace to [deleteMarkupBackward](https://github.com/codemirror/lang-markdown#user-content-deletemarkupbackward).

Thank you for your work on this project!