### PR TITLE
bugfix: last field content is lost while converting from md window input to separate fields

### DIFF
--- a/src/ts/window_input.ts
+++ b/src/ts/window_input.ts
@@ -41,11 +41,9 @@ class WindowEditor {
   get_html() {
     if (this[WINDOW_INPUT]?.[WINDOW_MODE] === 'note') {
       const fields: [title: string, content: string][] = []
-      const md = this.editor.cm.state.doc.toString()
-      for (const match of md.matchAll(/(.*?)^[ \t]*<!--[ \t]*(.*?)[ \t]*?-->[ \t]*$/gms)) {
-        if (fields.length)
-          fields[fields.length - 1][1] = this.converter.markdown_to_html(match[1].trim())
-        fields.push([match[2], ''])
+      const md = this.editor.cm.state.doc.toString() + "<!-- -->"
+      for (const match of md.matchAll(/<!--(.*?)-->(.*?)(?=<!--.*?-->)/gms)) {
+        fields.push([match[1].trim(), match[2].trim()])
       }
       return fields
     }


### PR DESCRIPTION
fixes #5 
To reproduce the bug just run this code part with the following input:
```
<!-- Front -->
Front content
<!-- Back -->
Back content
```

Back content is always lost